### PR TITLE
Dev

### DIFF
--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -500,10 +500,16 @@ def line_fit(file1,file2,file3,file_out,file_out2,name_out2,dir_out='',colors=['
     try:
         [pdl_cube, hdr]=fits.getdata(file1, 'FLUX', header=True)
     except:
-        [pdl_cube, hdr]=fits.getdata(file1, 0, header=True)
+        try:
+            [pdl_cube, hdr]=fits.getdata(file1, 'SCI', header=True)
+        except:
+            [pdl_cube, hdr]=fits.getdata(file1, 0, header=True)
     if error_c:
         try:
-            pdl_cubeE =fits.getdata(file1, 'ERROR', header=False)
+            try:
+                pdl_cubeE =fits.getdata(file1, 'ERROR', header=False)
+            except:
+                pdl_cubeE =fits.getdata(file1, 'ERR', header=False)
         except:
             try:
                 pdl_cubeE =fits.getdata(file1, 'IVAR', header=False)

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 import corner 
 import matplotlib.pyplot as plt
 
-def line_fit_single(file1,file_out,file_out2,name_out2,dir_out='',config_lines='line_prop.yml',labplot=True,input_format='TableFits',z=0.05536,lA1=6450.0,lA2=6850.0,verbose=True,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,ncpu=10,flux_f=1.0,erft=0.75,cont=False):
+def line_fit_single(file1,file_out,file_out2,name_out2,dir_out='',smoth=False,ker=2,config_lines='line_prop.yml',labplot=True,input_format='TableFits',z=0.05536,lA1=6450.0,lA2=6850.0,verbose=True,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,ncpu=10,flux_f=1.0,erft=0.75,cont=False):
     
     if input_format == 'TableFits':
         try:
@@ -124,7 +124,8 @@ def line_fit_single(file1,file_out,file_out2,name_out2,dir_out='',config_lines='
         print('Options are: TableFits, IrafFits, CSV, ASCII')
         return
  
-    
+    if smoth:
+        pdl_data=conv(pdl_data,ke=ker)
     nz=len(pdl_data)
     pdl_data=pdl_data*flux_f     
     wave_f=wave/(1+z)

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 import corner 
 import matplotlib.pyplot as plt
 
-def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.yml',input_format='TableFits',z=0.05536,lA1=6450.0,lA2=6850.0,verbose=True,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,ncpu=10,flux_f=1.0,erft=0.75,cont=False):
+def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.yml',labplot=True,input_format='TableFits',z=0.05536,lA1=6450.0,lA2=6850.0,verbose=True,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,ncpu=10,flux_f=1.0,erft=0.75,cont=False):
     
     if input_format == 'TableFits':
         hdu_list = fits.open(file1)
@@ -483,7 +483,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
     tol.sycall('gzip -f '+file_out2+'.fits')
 
 
-def line_fit(file1,file2,file3,file_out,file_out2,name_out2,z=0.05536,j_t=0,i_t=0,config_lines='line_prop.yml',lA1=6450.0,lA2=6850.0,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,test=False,plot_f=True,ncpu=10,pgr_bar=True,flux_f=1.0,erft=0,cont=False):
+def line_fit(file1,file2,file3,file_out,file_out2,name_out2,z=0.05536,j_t=0,i_t=0,labplot=True,config_lines='line_prop.yml',lA1=6450.0,lA2=6850.0,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,test=False,plot_f=True,ncpu=10,pgr_bar=True,flux_f=1.0,erft=0,cont=False):
     try:
         [pdl_cube, hdr]=fits.getdata(file1, 'FLUX', header=True)
     except:
@@ -795,7 +795,8 @@ def line_fit(file1,file2,file3,file_out,file_out2,name_out2,z=0.05536,j_t=0,i_t=
                     ax1.set_title("Observed Spectrum Input",fontsize=fontsize)
                     ax1.set_xlabel(r'$\lambda$ ($\rm{\AA}$)',fontsize=fontsize)
                     ax1.set_ylabel(r'$f_\lambda$ (10$^{-16}$erg cm$^{-2}$ s$^{-1}$ $\rm{\AA}^{-1}$)',fontsize=fontsize)
-                    ax1.legend(fontsize=fontsize)
+                    if labplot:
+                        ax1.legend(fontsize=fontsize)
                     plt.tight_layout()
                     fig.savefig('spectraFit_NAME.pdf'.replace('NAME',name_out2))
                     plt.show()

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -16,7 +16,10 @@ import matplotlib.pyplot as plt
 def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.yml',labplot=True,input_format='TableFits',z=0.05536,lA1=6450.0,lA2=6850.0,verbose=True,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,ncpu=10,flux_f=1.0,erft=0.75,cont=False):
     
     if input_format == 'TableFits':
-        hdu_list = fits.open(file1)
+        try:
+            hdu_list = fits.open(file1)
+        except:
+            hdu_list = fits.open(file1+'.gz')
         table_hdu = hdu_list[1]
         table_data = table_hdu.data
         try:

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -111,9 +111,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
  
     
     nz=len(pdl_data)
-    pdl_data=pdl_data*flux_f
-    
-    
+    pdl_data=pdl_data*flux_f     
     wave_f=wave/(1+z)
     nw=np.where((wave_f >= lA1) & (wave_f <= lA2))[0]
     wave_i=wave_f[nw]
@@ -122,8 +120,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
     model_InpE=np.zeros(len(nw))
     if outflow:
         model_Outflow=np.zeros(len(nw))
-    
-    
+       
     data_lines=tol.read_config_file(config_lines)
     if data_lines:
         n_lines=len(data_lines['lines'])

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -483,7 +483,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
     tol.sycall('gzip -f '+file_out2+'.fits')
 
 
-def line_fit(file1,file2,file3,file_out,file_out2,name_out2,z=0.05536,j_t=0,i_t=0,labplot=True,config_lines='line_prop.yml',lA1=6450.0,lA2=6850.0,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,test=False,plot_f=True,ncpu=10,pgr_bar=True,flux_f=1.0,erft=0,cont=False):
+def line_fit(file1,file2,file3,file_out,file_out2,name_out2,colors=['blue','red','purple','brown','pink'],z=0.05536,j_t=0,i_t=0,labplot=True,config_lines='line_prop.yml',lA1=6450.0,lA2=6850.0,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,test=False,plot_f=True,ncpu=10,pgr_bar=True,flux_f=1.0,erft=0,cont=False):
     try:
         [pdl_cube, hdr]=fits.getdata(file1, 'FLUX', header=True)
     except:
@@ -770,7 +770,6 @@ def line_fit(file1,file2,file3,file_out,file_out2,name_out2,z=0.05536,j_t=0,i_t=
                 
 
                 if plot_f:
-                    colors=['blue','red','purple','brown','pink']
                     fig = plt.figure(figsize=(7,5))
                     ax1 = fig.add_subplot(1,1,1)
                     ax1.plot(wave_i,fluxt,linewidth=1,color='black',label=r'Spectrum')

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -125,7 +125,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,dir_out='',smoth=False,ke
         return
  
     if smoth:
-        pdl_data=conv(pdl_data,ke=ker)
+        pdl_data=tol.conv(pdl_data,ke=ker)
     nz=len(pdl_data)
     pdl_data=pdl_data*flux_f     
     wave_f=wave/(1+z)

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 import corner 
 import matplotlib.pyplot as plt
 
-def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.yml',labplot=True,input_format='TableFits',z=0.05536,lA1=6450.0,lA2=6850.0,verbose=True,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,ncpu=10,flux_f=1.0,erft=0.75,cont=False):
+def line_fit_single(file1,file_out,file_out2,name_out2,dir_out='',config_lines='line_prop.yml',labplot=True,input_format='TableFits',z=0.05536,lA1=6450.0,lA2=6850.0,verbose=True,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,ncpu=10,flux_f=1.0,erft=0.75,cont=False):
     
     if input_format == 'TableFits':
         try:
@@ -394,7 +394,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
             ax1.set_ylabel(r'$f_\lambda$ (10$^{-16}$erg cm$^{-2}$ s$^{-1}$ $\rm{\AA}^{-1}$)',fontsize=fontsize)
             ax1.legend(fontsize=fontsize)
             plt.tight_layout()
-            fig.savefig('spectraFit_NAME.pdf'.replace('NAME',name_out2))
+            fig.savefig(dir_out+'spectraFit_NAME.pdf'.replace('NAME',name_out2))
             plt.show()
 
             if skew:
@@ -406,7 +406,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
                     labels2 = valsL
             fig = corner.corner(samples[:,0:len(labels2)],show_titles=True,labels=labels2,plot_datapoints=True,quantiles=[0.16, 0.5, 0.84],title_kwargs={"fontsize": 12},label_kwargs={"fontsize": 16})
             fig.set_size_inches(15.8*len(labels2)/8.0, 15.8*len(labels2)/8.0)    
-            fig.savefig('corners_NAME.pdf'.replace('NAME',name_out2))
+            fig.savefig(dir_out+'corners_NAME.pdf'.replace('NAME',name_out2))
                                    
             med_model, spread = mcm.sample_walkers(10, samples, waves0, fac0, facN0, velfac0, velfacN0, fwhfac0, fwhfacN0, names0, n_lines, vals, x=wave_i, skew=skew, lorentz=lorentz, outflow=outflow)
                        
@@ -421,7 +421,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
             ax1.fill_between(wave_i,med_model-spread*50,med_model+spread*50,color='grey',alpha=0.5,label=r'$1\sigma$ Posterior Spread')
             ax1.legend(fontsize=14)
             plt.tight_layout()
-            plt.savefig('spectra_mod_NAME.pdf'.replace('NAME',name_out2))
+            plt.savefig(dir_out+'spectra_mod_NAME.pdf'.replace('NAME',name_out2))
                 
             if verbose:    
                 #print Best fit parameters
@@ -495,7 +495,7 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
     tol.sycall('gzip -f '+file_out2+'.fits')
 
 
-def line_fit(file1,file2,file3,file_out,file_out2,name_out2,colors=['blue','red','purple','brown','pink'],z=0.05536,j_t=0,i_t=0,labplot=True,config_lines='line_prop.yml',lA1=6450.0,lA2=6850.0,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,test=False,plot_f=True,ncpu=10,pgr_bar=True,flux_f=1.0,erft=0,cont=False):
+def line_fit(file1,file2,file3,file_out,file_out2,name_out2,dir_out='',colors=['blue','red','purple','brown','pink'],z=0.05536,j_t=0,i_t=0,labplot=True,config_lines='line_prop.yml',lA1=6450.0,lA2=6850.0,outflow=False,voigt=False,lorentz=False,skew=False,error_c=True,test=False,plot_f=True,ncpu=10,pgr_bar=True,flux_f=1.0,erft=0,cont=False):
     try:
         [pdl_cube, hdr]=fits.getdata(file1, 'FLUX', header=True)
     except:
@@ -809,7 +809,7 @@ def line_fit(file1,file2,file3,file_out,file_out2,name_out2,colors=['blue','red'
                     if labplot:
                         ax1.legend(fontsize=fontsize)
                     plt.tight_layout()
-                    fig.savefig('spectraFit_NAME.pdf'.replace('NAME',name_out2))
+                    fig.savefig(dir_out+'spectraFit_NAME.pdf'.replace('NAME',name_out2))
                     plt.show()
 
 
@@ -823,7 +823,7 @@ def line_fit(file1,file2,file3,file_out,file_out2,name_out2,colors=['blue','red'
                                
                     fig = corner.corner(samples[:,0:len(labels2)],show_titles=True,labels=labels2,plot_datapoints=True,quantiles=[0.16, 0.5, 0.84],title_kwargs={"fontsize": 12},label_kwargs={"fontsize": 16})
                     fig.set_size_inches(15.8*len(labels2)/8.0, 15.8*len(labels2)/8.0)    
-                    fig.savefig('corners_NAME.pdf'.replace('NAME',name_out2))
+                    fig.savefig(dir_out+'corners_NAME.pdf'.replace('NAME',name_out2))
                 
                     
                     med_model, spread = mcm.sample_walkers(10, samples, waves0, fac0, facN0, velfac0, velfacN0, fwhfac0, fwhfacN0, names0, n_lines, vals, x=wave_i, skew=skew, lorentz=lorentz, outflow=outflow)
@@ -838,7 +838,7 @@ def line_fit(file1,file2,file3,file_out,file_out2,name_out2,colors=['blue','red'
                     ax1.fill_between(wave_i,med_model-spread*50,med_model+spread*50,color='grey',alpha=0.5,label=r'$1\sigma$ Posterior Spread')
                     ax1.legend(fontsize=14)
                     plt.tight_layout()
-                    plt.savefig('spectra_mod_NAME.pdf'.replace('NAME',name_out2))
+                    plt.savefig(dir_out+'spectra_mod_NAME.pdf'.replace('NAME',name_out2))
                 
                 if pgr_bar == False:  
                     linet=''

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -875,34 +875,49 @@ def line_fit(file1,file2,file3,file_out,file_out2,name_out2,dir_out='',colors=['
     h_k=hli[0].header
     keys=list(hdr.keys())
     for i in range(0, len(keys)):
-        h_k[keys[i]]=hdr[keys[i]]
-        h_k.comments[keys[i]]=hdr.comments[keys[i]]
+        try:
+            h_k[keys[i]]=hdr[keys[i]]
+            h_k.comments[keys[i]]=hdr.comments[keys[i]]
+        except:
+            continue
     h_k['EXTNAME'] ='Model'    
     h_k.update()
     for myt in range(0,n_lines):
         h_t=hli[1+myt].header
         for i in range(0, len(keys)):
-            h_t[keys[i]]=hdr[keys[i]]
-            h_t.comments[keys[i]]=hdr.comments[keys[i]]
+            try:
+                h_t[keys[i]]=hdr[keys[i]]
+                h_t.comments[keys[i]]=hdr.comments[keys[i]]
+            except:
+                continue
         h_t['EXTNAME'] ='N_Component'.replace('N',names0[myt])
         h_t.update()  
     h_y=hli[1+n_lines].header
     for i in range(0, len(keys)):
-        h_y[keys[i]]=hdr[keys[i]]
-        h_y.comments[keys[i]]=hdr.comments[keys[i]]
+        try:
+            h_y[keys[i]]=hdr[keys[i]]
+            h_y.comments[keys[i]]=hdr.comments[keys[i]]
+        except:
+            continue
     h_y['EXTNAME'] ='Input_Component'
     h_y.update()   
     h_y=hli[2+n_lines].header
     for i in range(0, len(keys)):
-        h_y[keys[i]]=hdr[keys[i]]
-        h_y.comments[keys[i]]=hdr.comments[keys[i]]
+        try:
+            h_y[keys[i]]=hdr[keys[i]]
+            h_y.comments[keys[i]]=hdr.comments[keys[i]]
+        except:
+            continue
     h_y['EXTNAME'] ='InputE_Component'
     h_y.update()  
     if outflow:
         h_y=hli[3+n_lines].header
         for i in range(0, len(keys)):
-            h_y[keys[i]]=hdr[keys[i]]
-            h_y.comments[keys[i]]=hdr.comments[keys[i]]
+            try:
+                h_y[keys[i]]=hdr[keys[i]]
+                h_y.comments[keys[i]]=hdr.comments[keys[i]]
+            except:
+                continue
         h_y['EXTNAME'] ='Outflow_Component'
         h_y.update()  
     hlist=fits.HDUList(hli)
@@ -914,9 +929,12 @@ def line_fit(file1,file2,file3,file_out,file_out2,name_out2,dir_out='',colors=['
     h=h1.header
     keys=list(hdr.keys())
     for i in range(0, len(keys)):
-        if not "COMMENT" in  keys[i] and not 'HISTORY' in keys[i]:
-            h[keys[i]]=hdr[keys[i]]
-            h.comments[keys[i]]=hdr.comments[keys[i]]
+        try:
+            if not "COMMENT" in  keys[i] and not 'HISTORY' in keys[i]:
+                h[keys[i]]=hdr[keys[i]]
+                h.comments[keys[i]]=hdr.comments[keys[i]]
+        except:
+            continue
     for i in range(0, len(valsH)):
         h['Val_'+str(i)]=valsH[i] 
     h['Val_'+str(n_lines*3)] ='Noise_Median'

--- a/MapLines/tools/line_fit.py
+++ b/MapLines/tools/line_fit.py
@@ -19,10 +19,22 @@ def line_fit_single(file1,file_out,file_out2,name_out2,config_lines='line_prop.y
         hdu_list = fits.open(file1)
         table_hdu = hdu_list[1]
         table_data = table_hdu.data
-        pdl_data=table_data.field('FLUX')
-        wave=table_data.field('LAMBDA')
+        try:
+            pdl_data=table_data.field('FLUX')
+        except:
+            pdl_data=table_data.field('flux')
+        try:
+            wave=table_data.field('LAMBDA')
+        except:
+            try:
+                wave=table_data.field('lambda')
+            except:
+                wave=table_data.field('wave')
         if error_c:
-            pdl_dataE=table_data.field('ERROR')
+            try:
+                pdl_dataE=table_data.field('ERROR')
+            except:
+                pdl_dataE=table_data.field('fluxE')
             if erft != 0:
                 pdl_dataE=pdl_dataE*flux_f*erft
             else:

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -13,7 +13,7 @@ from astropy.wcs import WCS
 from astropy.io import fits
 import MapLines.tools.tools as tools
 
-def plot_bpt_map(file,valmax,valmin,name='',alpha=1,orientation=None,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
+def plot_bpt_map(file,name='',alpha=1,orientation=None,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
     basefigname='BPT_map_NAME',
     [data,hdr]=fits.getdata(path+'/'+file, hd, header=True)
     try:

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -13,7 +13,7 @@ from astropy.wcs import WCS
 from astropy.io import fits
 import MapLines.tools.tools as tools
 
-def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,max_typ=5,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
+def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,ewsing=1,max_typ=5,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
     basefigname='BPT_map_NAME'
     [data,hdr]=fits.getdata(path+'/'+file, hd, header=True)
     try:
@@ -35,15 +35,13 @@ def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,max_typ=5,location=N
     fluxNII=data[indNII,:,:]
     fluxHa=data[indHa,:,:]
     fluxHb=data[indHb,:,:]
-    ewHa=data[indEwHa,:,:]
+    ewHa=ewsing*data[indEwHa,:,:]
 
     ratio1=np.log10(fluxOIII/fluxHb)
     ratio2=np.log10(fluxNII/fluxHa)
-    print(ewHa)
     bounds = np.arange(0, max_typ + 1) + 0.5  # Para centrar los ticks
     map_bpt=tools.bpt(ewHa,ratio2,ratio1,ret=ret,agn=agn,sf=sf,inte=inte,comp=comp)
-    print(map_bpt)
-
+    
     type_p=r'log($[OIII]H\beta$)~vs~log($[NII]H\alpha$)'
     type_n=r'log($[OIII]/H\beta$) vs log($[NII]/H\alpha$)'
     vmax=None

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -39,8 +39,9 @@ def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,max_typ=5,location=N
 
     ratio1=np.log10(fluxOIII/fluxHb)
     ratio2=np.log10(fluxNII/fluxHa)
+    print(ratio2)
     bounds = np.arange(0, max_typ + 1) + 0.5  # Para centrar los ticks
-    map_bpt=tools.bpt(ewHa,ratio2,ratio1,ret=1,agn=5,sf=3,inte=2,comp=4)
+    map_bpt=tools.bpt(ewHa,ratio2,ratio1,ret=ret,agn=agn,sf=sf,inte=inte,comp=comp)
 
     type_p=r'log($[OIII]H\beta$)~vs~log($[NII]H\alpha$)'
     type_n=r'log($[OIII]/H\beta$) vs log($[NII]/H\alpha$)'

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -63,7 +63,7 @@ def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,ewsing=1,max_typ=5,l
 
     cm = ListedColormap(colores)
     norm = colors.BoundaryNorm(boundaries=bounds, ncolors=cm.N)#niveles, len(colores))
-    get_plot_map(plt,map_bpt,vmax,vmin,cmt=cm,norm=norm,fwcs=fwcs,objsys=objsys,pix=pix,tit=tit,scale=scale,lab=type_n,cont=cont,orientation=orientation,location=location,alpha=alpha)
+    get_plot_map(plt,map_bpt,vmax,vmin,cmt=cm,labels=labels,norm=norm,fwcs=fwcs,objsys=objsys,pix=pix,tit=tit,scale=scale,lab=type_n,cont=cont,orientation=orientation,location=location,alpha=alpha)
     if fwcs:
         plt.grid(color='black', ls='solid')
     if savef:
@@ -124,7 +124,7 @@ def plot_single_map(file,valmax,valmin,name='',scale=0,sb=False,fwcs=False,logs=
     else:
         plt.show()
 
-def get_plot_map(plt,flux,vmax,vmin,pix=0.2,scale=0,cmt=None,norm=None,fwcs=False,objsys='J2000',tit='flux',lab='[10^{-16}erg/s/cm^2/arcsec^2]',cont=False,alpha=1,orientation=None,location=None):
+def get_plot_map(plt,flux,vmax,vmin,pix=0.2,scale=0,labels=None,cmt=None,norm=None,fwcs=False,objsys='J2000',tit='flux',lab='[10^{-16}erg/s/cm^2/arcsec^2]',cont=False,alpha=1,orientation=None,location=None):
     nx,ny=flux.shape
     if fwcs:
         pix=3600.
@@ -178,7 +178,9 @@ def get_plot_map(plt,flux,vmax,vmin,pix=0.2,scale=0,cmt=None,norm=None,fwcs=Fals
     if location == 'top':
         cbar.set_label(r"$"+tit+r"\ "+lab+"$",fontsize=18)
     else:
-        cbar.set_label(r"$"+lab+"$",fontsize=18)      
+        cbar.set_label(r"$"+lab+"$",fontsize=18)  
+    if labels is not None:
+        cbar.set_ticklabels(labels)       
 
 def get_plot(flux,savef=True,pix=0.2,name='Residual',tit='flux',outs=[],title=None,cbtr=True,bpte=False,maxmin=[],ewp=False):
     nx,ny=flux.shape

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -63,7 +63,7 @@ def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,max_typ=5,location=N
 
     cm = ListedColormap(colores)
     norm = colors.BoundaryNorm(boundaries=bounds, ncolors=cm.N)#niveles, len(colores))
-    get_plot_map(plt,map_bpt,valmax,valmin,cmt=cm,norm=norm,fwcs=fwcs,objsys=objsys,pix=pix,tit=tit,scale=scale,lab=type_n,cont=cont,orientation=orientation,location=location,alpha=alpha)
+    get_plot_map(plt,map_bpt,vmax,vmin,cmt=cm,norm=norm,fwcs=fwcs,objsys=objsys,pix=pix,tit=tit,scale=scale,lab=type_n,cont=cont,orientation=orientation,location=location,alpha=alpha)
     if fwcs:
         plt.grid(color='black', ls='solid')
     if savef:

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -13,7 +13,7 @@ from astropy.wcs import WCS
 from astropy.io import fits
 import MapLines.tools.tools as tools
 
-def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
+def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,max_typ=5,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
     basefigname='BPT_map_NAME',
     [data,hdr]=fits.getdata(path+'/'+file, hd, header=True)
     try:

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -13,7 +13,7 @@ from astropy.wcs import WCS
 from astropy.io import fits
 import MapLines.tools.tools as tools
 
-def plot_bpt_map(file,name='',alpha=1,orientation=None,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
+def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
     basefigname='BPT_map_NAME',
     [data,hdr]=fits.getdata(path+'/'+file, hd, header=True)
     try:

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -63,7 +63,7 @@ def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,ewsing=1,max_typ=5,l
 
     cm = ListedColormap(colores)
     norm = colors.BoundaryNorm(boundaries=bounds, ncolors=cm.N)#niveles, len(colores))
-    get_plot_map(plt,map_bpt,vmax,vmin,cmt=cm,labels=labels,norm=norm,fwcs=fwcs,objsys=objsys,pix=pix,tit=tit,scale=scale,lab=type_n,cont=cont,orientation=orientation,location=location,alpha=alpha)
+    get_plot_map(plt,map_bpt,vmax,vmin,cmt=cm,ticks=ticks,labels=labels,norm=norm,fwcs=fwcs,objsys=objsys,pix=pix,tit=tit,scale=scale,lab=type_n,cont=cont,orientation=orientation,location=location,alpha=alpha)
     if fwcs:
         plt.grid(color='black', ls='solid')
     if savef:
@@ -124,7 +124,7 @@ def plot_single_map(file,valmax,valmin,name='',scale=0,sb=False,fwcs=False,logs=
     else:
         plt.show()
 
-def get_plot_map(plt,flux,vmax,vmin,pix=0.2,scale=0,labels=None,cmt=None,norm=None,fwcs=False,objsys='J2000',tit='flux',lab='[10^{-16}erg/s/cm^2/arcsec^2]',cont=False,alpha=1,orientation=None,location=None):
+def get_plot_map(plt,flux,vmax,vmin,pix=0.2,scale=0,ticks=None,labels=None,cmt=None,norm=None,fwcs=False,objsys='J2000',tit='flux',lab='[10^{-16}erg/s/cm^2/arcsec^2]',cont=False,alpha=1,orientation=None,location=None):
     nx,ny=flux.shape
     if fwcs:
         pix=3600.
@@ -172,7 +172,10 @@ def get_plot_map(plt,flux,vmax,vmin,pix=0.2,scale=0,labels=None,cmt=None,norm=No
     ict=plt.imshow(flux,cmap=cm,norm=norm,origin='lower',extent=[-ny*pix/2./fac+dx,ny*pix/2./fac+dx,-nx*pix/2./fac+dy,nx*pix/2./fac+dy],vmax=vmax,vmin=vmin,alpha=alpha)#,norm=LogNorm(0.2,7.0))#colors.SymLogNorm(10**-1))#50  norm=colors.SymLogNorm(10**-0.1)
     if cont:
         plt.contour(flux,lev,colors='black',linewidths=2,extent=[-ny*pix/2./fac+dx,ny*pix/2./fac+dx,-nx*pix/2./fac+dy,nx*pix/2./fac+dy],zorder=1)
-    cbar=plt.colorbar(ict,orientation=orientation,location=location)
+    if ticks is not None:
+        cbar=plt.colorbar(ict,orientation=orientation,location=location,ticks = ticks,pad=0.01)
+    else:
+        cbar=plt.colorbar(ict,orientation=orientation,location=location)
     plt.xlim(-ny*pix/2/fac+dx,ny*pix/2/fac+dx)
     plt.ylim(-nx*pix/2/fac+dy,nx*pix/2/fac+dy)  
     if location == 'top':

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -39,9 +39,10 @@ def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,max_typ=5,location=N
 
     ratio1=np.log10(fluxOIII/fluxHb)
     ratio2=np.log10(fluxNII/fluxHa)
-    print(ratio2)
+    print(ewHa)
     bounds = np.arange(0, max_typ + 1) + 0.5  # Para centrar los ticks
     map_bpt=tools.bpt(ewHa,ratio2,ratio1,ret=ret,agn=agn,sf=sf,inte=inte,comp=comp)
+    print(map_bpt)
 
     type_p=r'log($[OIII]H\beta$)~vs~log($[NII]H\alpha$)'
     type_n=r'log($[OIII]/H\beta$) vs log($[NII]/H\alpha$)'

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -19,21 +19,17 @@ def plot_single_map(file,valmax,valmin,name='',scale=0,sb=False,fwcs=False,logs=
     try:
         dx=np.sqrt((hdr['CD1_1'])**2.0+(hdr['CD1_2'])**2.0)*3600.0
         dy=np.sqrt((hdr['CD2_1'])**2.0+(hdr['CD2_2'])**2.0)*3600.0
-        print('A')
     except:
         try:
             dx=hdr['CD1_1']*3600.0
             dy=hdr['CD2_2']*3600.0
-            print('B')
         except:
             try:
                 dx=hdr['PC1_1']*3600.
                 dy=hdr['PC2_2']*3600.
-                print('C')
             except:
                 dx=hdr['CDELT1']*3600.
                 dy=hdr['CDELT2']*3600.
-                print('D')
     pix=(np.abs(dx)+np.abs(dy))/2.0 
     map_val=data[indx,:,:]*scalef
     if indx2 != None:

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -13,7 +13,7 @@ from astropy.wcs import WCS
 from astropy.io import fits
 import MapLines.tools.tools as tools
 
-def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,ewsing=1,max_typ=5,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
+def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,ewsing=1,max_typ=5,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=63,ret=1,agn=5,sf=3,inte=2,comp=4):
     basefigname='BPT_map_NAME'
     [data,hdr]=fits.getdata(path+'/'+file, hd, header=True)
     try:

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -19,17 +19,21 @@ def plot_single_map(file,valmax,valmin,name='',scale=0,sb=False,fwcs=False,logs=
     try:
         dx=np.sqrt((hdr['CD1_1'])**2.0+(hdr['CD1_2'])**2.0)*3600.0
         dy=np.sqrt((hdr['CD2_1'])**2.0+(hdr['CD2_2'])**2.0)*3600.0
+        print('A')
     except:
         try:
             dx=hdr['CD1_1']*3600.0
             dy=hdr['CD2_2']*3600.0
+            print('B')
         except:
             try:
                 dx=hdr['PC1_1']*3600.
                 dy=hdr['PC2_2']*3600.
+                print('C')
             except:
                 dx=hdr['CDELT1']*3600.
                 dy=hdr['CDELT2']*3600.
+                print('D')
     pix=(np.abs(dx)+np.abs(dy))/2.0 
     map_val=data[indx,:,:]*scalef
     if indx2 != None:

--- a/MapLines/tools/plot_tools.py
+++ b/MapLines/tools/plot_tools.py
@@ -14,7 +14,7 @@ from astropy.io import fits
 import MapLines.tools.tools as tools
 
 def plot_bpt_map(file,name='',alpha=1,orientation=None,hd=0,max_typ=5,location=None,savef=False,fig_path='',fwcs=False,scale=0,facp=0.8,tit='BPT',cont=False,path='',indEwHa=769,indOIII=76,indNII=123,indHa=124,indHb=76,ret=1,agn=5,sf=3,inte=2,comp=4):
-    basefigname='BPT_map_NAME',
+    basefigname='BPT_map_NAME'
     [data,hdr]=fits.getdata(path+'/'+file, hd, header=True)
     try:
         dx=np.sqrt((hdr['CD1_1'])**2.0+(hdr['CD1_2'])**2.0)*3600.0

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -561,6 +561,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
         if 'VAL_' in key:
             head_val= hdr[key]
             if 'Continum' in head_val:
+                idx = int(key.replace('VAL_', ''))
                 cont=mapdata[idx,:,:]
                 indx = np.where(cont == 0)
     for key in keys:

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -562,7 +562,7 @@ def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=
     if logP:
         map=np.log10(map)      
     if smoth:
-        map[np.where(map < ofsval)]=ofsval
+        #map[np.where(map < ofsval)]=ofsval
         map[np.where(np.isfinite(map) == False)]=ofsval
         map=filtNd(map, sigma=sig)
     if maxval is None:

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -545,7 +545,7 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
-def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False:
+def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False):
     """
     Convert a 2D map from a FITS file to an STL file.
     

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import numpy as np
 from scipy.ndimage import gaussian_filter1d as filt1d
+from scipy.ndimage import gaussian_filter as filtNd
 import os
 import os.path as ptt
 from scipy.special import erf as errf
@@ -544,7 +545,7 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
-def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
+def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=False):
     """
     Convert a 2D map from a FITS file to an STL file.
     
@@ -572,6 +573,8 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
             map[indx] = np.nan
             if 'Amplitude' in head_val:
                 map=np.log10(map)
+            if smoth:
+                map=filtNd(map, sigma=sig)
             maxval=np.nanmax(map)
             minval=np.nanmin(map)#[np.where(map > 1.8)])
             map=(map-minval)/(maxval-minval)*27+0

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -564,7 +564,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
             if 'Continum' in head_val:
                 idx = int(key.replace('VAL_', ''))
                 cont=mapdata[idx,:,:]
-                indx = np.where(cont == 0)
+                indx = np.where(cont == 0)[0]
     for key in keys:
         if 'VAL_' in key:
             head_val= hdr[key]

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -466,7 +466,7 @@ def extract_single_reg(map,hdr,ra='',dec='',rad=1.5,pix=0.35,avgra=False):
     return value
 
 
-def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5,save=False,path='',name='BPT_map'):
+def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5,save=False,path='',name='BPT_map',hdr=None):
     nt1=np.where((wha >=6) & ((oiiihb-0.61/(niiha-0.47)-1.19) > 0) & (np.isfinite(oiiihb)) & (np.isnan(oiiihb) == False) & (np.isfinite(niiha)) & (np.isnan(niiha) == False))#AGN
     nt2=np.where((wha >=6) & ((oiiihb-0.61/(niiha-0.47)-1.19) <= 0) & ((oiiihb-0.61/(niiha-0.05)-1.3) > 0) & (np.isfinite(oiiihb)) & (np.isnan(niiha) == False) & (np.isfinite(niiha)) & (np.isnan(niiha) == False))#COMP
     nt3=np.where((wha >=6) & ((oiiihb-0.61/(niiha-0.05)-1.3) <= 0) & (np.isfinite(oiiihb)) & (np.isnan(niiha) == False) & (np.isfinite(niiha)) & (np.isnan(niiha) == False))#SF
@@ -482,6 +482,10 @@ def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5,save=False,path='',nam
     image[nt5]=ret
     if save:
         filename=path+name+'.fits'
+        if hdr:
+            h1=fits.PrimaryHDU(image,header=hdr)
+        else:
+            h1=fits.PrimaryHDU(image)
         h1=fits.PrimaryHDU(image)
         hlist=fits.HDUList([h1])
         hlist.update_extend()
@@ -489,7 +493,7 @@ def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5,save=False,path='',nam
         sycall('gzip -f '+filename)
     return image
 
-def whan(wha,niiha,agn=4,sf=1.7,wagn=3,ret=1,save=False,path='',name='WHAN_map'):
+def whan(wha,niiha,agn=4,sf=1.7,wagn=3,ret=1,save=False,path='',name='WHAN_map',hdr=None):
     nt1=np.where((wha >  6) & (niiha >= -0.4))#sAGN
     nt2=np.where((wha >= 3) & (niiha < -0.4))#SFR
     nt3=np.where((wha >= 3) & (wha <= 6) & (niiha >= -0.4))#wAGN
@@ -502,7 +506,10 @@ def whan(wha,niiha,agn=4,sf=1.7,wagn=3,ret=1,save=False,path='',name='WHAN_map')
     image[nt4]=ret
     if save:
         filename=path+name+'.fits'
-        h1=fits.PrimaryHDU(image)
+        if hdr:
+            h1=fits.PrimaryHDU(image,header=hdr)
+        else:
+            h1=fits.PrimaryHDU(image)
         hlist=fits.HDUList([h1])
         hlist.update_extend()
         hlist.writeto(filename, overwrite=True)
@@ -510,7 +517,7 @@ def whan(wha,niiha,agn=4,sf=1.7,wagn=3,ret=1,save=False,path='',name='WHAN_map')
     return image    
 
 
-def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHAD_map'):
+def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHAD_map',hdr=None):
     nt1=np.where((logew>=np.log10(10)) & (logsig>=np.log10(57))) #AGN
     nt2=np.where((logew>=np.log10(6)) & (logsig<np.log10(57))) #SF
     nt3=np.where((logew>=np.log10(3)) & (logew<np.log10(10)) & (logsig>=np.log10(57))) #WAGN
@@ -525,6 +532,10 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
     image[nt5]=unk
     if save:
         filename=path+name+'.fits'
+        if hdr:
+            h1=fits.PrimaryHDU(image,header=hdr)
+        else:
+            h1=fits.PrimaryHDU(image)
         h1=fits.PrimaryHDU(image)
         hlist=fits.HDUList([h1])
         hlist.update_extend()

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -565,6 +565,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
                 idx = int(key.replace('VAL_', ''))
                 cont=mapdata[idx,:,:]
                 indx = np.where(cont == 0)
+                indxt= np.where(cont != 0)
     for key in keys:
         if 'VAL_' in key:
             head_val= hdr[key]
@@ -573,12 +574,14 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             map[indx] = np.nan
             if 'Amplitude' in head_val:
                 map=np.log10(map)
+            maxval=np.nanmax(map[indxt])
+            minval=np.nanmin(map[indxt])    
+            map[np.where(np.isfinite(map) == False)]=0    
             if smoth:
                 map=filtNd(map, sigma=sig)
-            maxval=np.nanmax(map)
-            minval=np.nanmin(map)#[np.where(map > 1.8)])
             map=(map-minval)/(maxval-minval)*27+0
             map[np.where(np.isfinite(map) == False)]=0
+            map[indx]=0
             map[np.where(map < 0)]=0
             # Convert the map to STL format
             map_to_stl(map, head_val+nameid, path_out)

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -562,6 +562,7 @@ def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=
     if logP:
         map=np.log10(map)      
     if smoth:
+        map[np.where(map < ofsval)]=ofsval
         map[np.where(np.isfinite(map) == False)]=ofsval
         map=filtNd(map, sigma=sig)
     maxval=np.nanmax(map[indxt])

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -581,7 +581,12 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
                 map=filtNd(map, sigma=sig)
             maxval=np.nanmax(map[indxt])
             minval=np.nanmin(map[indxt])
+            print('Max:',maxval,'Min:',minval)
             map=(map-minval)/(maxval-minval)*27+0
+            maxval=np.nanmax(map[indxt])
+            minval=np.nanmin(map[indxt])
+            print('Max:',maxval,'Min:',minval)
+            print('----')
             map[np.where(np.isfinite(map) == False)]=0
             map[indx]=0
             map[np.where(map < 0)]=0

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -545,7 +545,7 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
-def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=False, pval=27, mval=0):
+def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False:
     """
     Convert a 2D map from a FITS file to an STL file.
     
@@ -573,9 +573,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             map=mapdata[idx,:,:]
             map[indx] = np.nan
             if 'Amplitude' in head_val or 'Continum' in head_val:
-                map=np.log10(map)
-            #maxval=np.nanmax(map[indxt])
-            #minval=np.nanmin(map[indxt])        
+                map=np.log10(map)      
             if smoth:
                 map[np.where(np.isfinite(map) == False)]=-2
                 map=filtNd(map, sigma=sig)
@@ -585,6 +583,10 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             map[np.where(np.isfinite(map) == False)]=0
             map[indx]=0
             map[np.where(map < 0)]=0
+            if border:
+                nx,ny=map.shape
+                map[0:1,0:ny]=0
+                map[ny-1:ny,0:ny]=0
             # Convert the map to STL format
             map_to_stl(map, head_val+nameid, path_out)
 

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -472,7 +472,7 @@ def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5):
     nt2=np.where((wha >=6) & ((oiiihb-0.61/(niiha-0.47)-1.19) <= 0) & ((oiiihb-0.61/(niiha-0.05)-1.3) > 0) & (np.isfinite(oiiihb)) & (np.isnan(niiha) == False) & (np.isfinite(niiha)) & (np.isnan(niiha) == False))#COMP
     nt3=np.where((wha >=6) & ((oiiihb-0.61/(niiha-0.05)-1.3) <= 0) & (np.isfinite(oiiihb)) & (np.isnan(niiha) == False) & (np.isfinite(niiha)) & (np.isnan(niiha) == False))#SF
     nt4=np.where((wha > 3) & (wha <6))#INT
-    nt5=np.where((wha <=3))#RET
+    nt5=np.where((wha <=3) & (wha > 0))#RET
     image=np.copy(niiha)
     image=image*0
     image[:,:]=np.nan

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -580,7 +580,7 @@ def get_maps_to_stl(file_in, file_out, path_in='', path_out=''):
             map[np.where(np.isfinite(map) == False)]=0
             map[np.where(map < 0)]=0
             # Convert the map to STL format
-            map_to_stl(map, file_out, path_out)
+            map_to_stl(map, head_val, path_out)
 
 def map_to_stl(map, file_out, path_out=''):
     nx, ny = map.shape

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -575,10 +575,10 @@ def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=
     map[np.where(map < 0)]=0
     if border:
         nx,ny=map.shape
-        map[0:1,0:ny]=0
-        map[nx-1:nx,0:ny]=0
-        map[0:nx,0:1]=0
-        map[0:nx,ny-1:ny]=0
+        map[0:3,0:ny]=0#1
+        map[nx-3:nx,0:ny]=0
+        map[0:nx,0:3]=0
+        map[0:nx,ny-3:ny]=0
     # Convert the map to STL format
     map_to_stl(map, nameid, path_out)
 

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -486,7 +486,6 @@ def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5,save=False,path='',nam
             h1=fits.PrimaryHDU(image,header=hdr)
         else:
             h1=fits.PrimaryHDU(image)
-        h1=fits.PrimaryHDU(image)
         hlist=fits.HDUList([h1])
         hlist.update_extend()
         hlist.writeto(filename, overwrite=True)

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -577,7 +577,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             #maxval=np.nanmax(map[indxt])
             #minval=np.nanmin(map[indxt])        
             if smoth:
-                map[np.where(np.isfinite(map) == False)]=0
+                map[np.where(np.isfinite(map) == False)]=-2
                 map=filtNd(map, sigma=sig)
             maxval=np.nanmax(map[indxt])
             minval=np.nanmin(map[indxt])

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -557,6 +557,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
     # Read the FITS file
     mapdata, hdr = fits.getdata(path_in + file_in, header=True)
     keys = hdr.keys()
+    print(keys)
     for key in keys:
         if 'VAL_' in key:
             head_val= hdr[key]

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -544,7 +544,7 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
-def get_maps_to_stl(file_in, path_in='', path_out=''):
+def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
     """
     Convert a 2D map from a FITS file to an STL file.
     
@@ -580,7 +580,7 @@ def get_maps_to_stl(file_in, path_in='', path_out=''):
             map[np.where(np.isfinite(map) == False)]=0
             map[np.where(map < 0)]=0
             # Convert the map to STL format
-            map_to_stl(map, head_val, path_out)
+            map_to_stl(map, head_val+nameid, path_out)
 
 def map_to_stl(map, file_out, path_out=''):
     nx, ny = map.shape

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -563,9 +563,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
             if 'Continum' in head_val:
                 idx = int(key.replace('VAL_', ''))
                 cont=mapdata[idx,:,:]
-                indx = np.where(cont == 0)[0]
-                print(idx)
-                print(indx)
+                indx = np.where(cont == 0)
     for key in keys:
         if 'VAL_' in key:
             head_val= hdr[key]
@@ -573,8 +571,6 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
             map=mapdata[idx,:,:]
             map[indx] = np.nan
             if 'Amplitude' in head_val:
-                map[np.where(np.isfinite(map) == False)]=1
-                map[np.where(map == 0)]=1
                 map=np.log10(map)
             maxval=np.nanmax(map)
             minval=np.nanmin(map)#[np.where(map > 1.8)])

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -569,8 +569,18 @@ def get_maps_to_stl(file_in, file_out, path_in='', path_out=''):
             idx = int(key.replace('VAL_', ''))
             map=mapdata[idx,:,:]
             map[indx] = np.nan
-    # Convert the map to STL format
-    map_to_stl(map, file_out, path_out)
+            if 'Amplitude' in head_val:
+                map[np.where(np.isfinite(map) == False)]=1
+                map[np.where(map == 0)]=1
+                map=np.log10(map)
+            maxval=np.nanmax(map)
+            minval=np.nanmin(map)#[np.where(map > 1.8)])
+            #print(minval)
+            map=(map-minval)/(maxval-minval)*27+0
+            map[np.where(np.isfinite(map) == False)]=0
+            map[np.where(map < 0)]=0
+            # Convert the map to STL format
+            map_to_stl(map, file_out, path_out)
 
 def map_to_stl(map, file_out, path_out=''):
     nx, ny = map.shape

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -544,6 +544,34 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
+def get_maps_to_stl(file_in, file_out, path_in='', path_out=''):
+    """
+    Convert a 2D map from a FITS file to an STL file.
+    
+    Parameters:
+    - file_in: Input FITS file containing the map.
+    - file_out: Output STL file name.
+    - path_in: Path to the input FITS file.
+    - path_out: Path to save the output STL file.
+    """
+    # Read the FITS file
+    mapdata, hdr = fits.getdata(path_in + file_in, header=True)
+    keys = hdr.keys()
+    for key in keys:
+        if 'VAL_' in key:
+            head_val= hdr[key]
+            if 'Continum' in head_val:
+                cont=mapdata[idx,:,:]
+                indx = np.where(cont == 0)
+    for key in keys:
+        if 'VAL_' in key:
+            head_val= hdr[key]
+            idx = int(key.replace('VAL_', ''))
+            map=mapdata[idx,:,:]
+            map[indx] = np.nan
+    # Convert the map to STL format
+    map_to_stl(map, file_out, path_out)
+
 def map_to_stl(map, file_out, path_out=''):
     nx, ny = map.shape
     x = np.arange(nx)

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -547,7 +547,7 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
-def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False,logP=False,ofsval=-1):
+def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False,logP=False,ofsval=-1,maxval=None,minval=None):
     """
     Convert a 2D map to an STL file.
     
@@ -565,8 +565,10 @@ def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=
         map[np.where(map < ofsval)]=ofsval
         map[np.where(np.isfinite(map) == False)]=ofsval
         map=filtNd(map, sigma=sig)
-    maxval=np.nanmax(map[indxt])
-    minval=np.nanmin(map[indxt])
+    if maxval is None:
+        maxval=np.nanmax(map[indxt])
+    if minval is None:
+        minval=np.nanmin(map[indxt])
     map=(map-minval)/(maxval-minval)*pval+mval
     map[np.where(np.isfinite(map) == False)]=0
     map[indx]=0

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -557,7 +557,6 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
     # Read the FITS file
     mapdata, hdr = fits.getdata(path_in + file_in, header=True)
     keys = list(hdr.keys())
-    print(keys)
     for key in keys:
         if 'VAL_' in key:
             head_val= hdr[key]
@@ -565,6 +564,8 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
                 idx = int(key.replace('VAL_', ''))
                 cont=mapdata[idx,:,:]
                 indx = np.where(cont == 0)[0]
+                print(idx)
+                print(indx)
     for key in keys:
         if 'VAL_' in key:
             head_val= hdr[key]
@@ -577,7 +578,6 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
                 map=np.log10(map)
             maxval=np.nanmax(map)
             minval=np.nanmin(map)#[np.where(map > 1.8)])
-            print(head_val)
             map=(map-minval)/(maxval-minval)*27+0
             map[np.where(np.isfinite(map) == False)]=0
             map[np.where(map < 0)]=0

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -535,7 +535,6 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
             h1=fits.PrimaryHDU(image,header=hdr)
         else:
             h1=fits.PrimaryHDU(image)
-        h1=fits.PrimaryHDU(image)
         hlist=fits.HDUList([h1])
         hlist.update_extend()
         hlist.writeto(filename, overwrite=True)

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -547,7 +547,7 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
-def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False,logP=False):
+def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False,logP=False,ofsval=-1):
     """
     Convert a 2D map to an STL file.
     
@@ -562,7 +562,7 @@ def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=
     if logP:
         map=np.log10(map)      
     if smoth:
-        map[np.where(np.isfinite(map) == False)]=-2
+        map[np.where(np.isfinite(map) == False)]=ofsval
         map=filtNd(map, sigma=sig)
     maxval=np.nanmax(map[indxt])
     minval=np.nanmin(map[indxt])

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -544,7 +544,7 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
-def get_maps_to_stl(file_in, file_out, path_in='', path_out=''):
+def get_maps_to_stl(file_in, path_in='', path_out=''):
     """
     Convert a 2D map from a FITS file to an STL file.
     

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -572,7 +572,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             idx = int(key.replace('VAL_', ''))
             map=mapdata[idx,:,:]
             map[indx] = np.nan
-            if 'Amplitude' in head_val:
+            if 'Amplitude' in head_val or 'Continum' in head_val:
                 map=np.log10(map)
             #maxval=np.nanmax(map[indxt])
             #minval=np.nanmin(map[indxt])        

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -588,7 +588,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             if border:
                 nx,ny=map.shape
                 map[0:1,0:ny]=0
-                map[ny-1:ny,0:ny]=0
+                map[nx-1:nx,0:ny]=0
             # Convert the map to STL format
             map_to_stl(map, head_val+nameid, path_out)
 

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -574,11 +574,13 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             map[indx] = np.nan
             if 'Amplitude' in head_val:
                 map=np.log10(map)
-            maxval=np.nanmax(map[indxt])
-            minval=np.nanmin(map[indxt])    
-            map[np.where(np.isfinite(map) == False)]=0    
+            #maxval=np.nanmax(map[indxt])
+            #minval=np.nanmin(map[indxt])        
             if smoth:
+                map[np.where(np.isfinite(map) == False)]=0
                 map=filtNd(map, sigma=sig)
+            maxval=np.nanmax(map[indxt])
+            minval=np.nanmin(map[indxt])
             map=(map-minval)/(maxval-minval)*27+0
             map[np.where(np.isfinite(map) == False)]=0
             map[indx]=0

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -581,12 +581,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
                 map=filtNd(map, sigma=sig)
             maxval=np.nanmax(map[indxt])
             minval=np.nanmin(map[indxt])
-            print('Max:',maxval,'Min:',minval)
             map=(map-minval)/(maxval-minval)*pval+mval
-            maxval=np.nanmax(map[indxt])
-            minval=np.nanmin(map[indxt])
-            print('Max:',maxval,'Min:',minval)
-            print('----')
             map[np.where(np.isfinite(map) == False)]=0
             map[indx]=0
             map[np.where(map < 0)]=0

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -562,7 +562,7 @@ def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=
     if logP:
         map=np.log10(map)      
     if smoth:
-        #map[np.where(map < ofsval)]=ofsval
+        map[np.where(map < ofsval)]=ofsval
         map[np.where(np.isfinite(map) == False)]=ofsval
         map=filtNd(map, sigma=sig)
     if maxval is None:

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -595,7 +595,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             map_to_stl(map, head_val+nameid, path_out)
 
 def map_to_stl(map, file_out, path_out=''):
-    nx, ny = map.shape
+    ny, nx = map.shape
     x = np.arange(nx)
     y = np.arange(ny) 
     X, Y = np.meshgrid(x, y)

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -111,7 +111,6 @@ def get_fluxline(file,path='',ind1=3,ind2=7,ind3=4,ind4=9,lo=6564.632,zt=0.0,val
     vel=pdl_cube0[ind3,:,:]
     nt=np.where(np.round(vel,decimals=3) == val0)
     vel=vel+zt*ct
-    
     try:
         cont=pdl_cube0[ind4,:,:]
         conti=True

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -545,7 +545,7 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
-def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=False):
+def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=False, pval=27, mval=0):
     """
     Convert a 2D map from a FITS file to an STL file.
     
@@ -582,7 +582,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
             maxval=np.nanmax(map[indxt])
             minval=np.nanmin(map[indxt])
             print('Max:',maxval,'Min:',minval)
-            map=(map-minval)/(maxval-minval)*27+0
+            map=(map-minval)/(maxval-minval)*pval+mval
             maxval=np.nanmax(map[indxt])
             minval=np.nanmin(map[indxt])
             print('Max:',maxval,'Min:',minval)

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -589,6 +589,8 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=Fals
                 nx,ny=map.shape
                 map[0:1,0:ny]=0
                 map[nx-1:nx,0:ny]=0
+                map[0:nx,0:1]=0
+                map[0:nx,ny-1:ny]=0
             # Convert the map to STL format
             map_to_stl(map, head_val+nameid, path_out)
 

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -576,7 +576,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
                 map=np.log10(map)
             maxval=np.nanmax(map)
             minval=np.nanmin(map)#[np.where(map > 1.8)])
-            #print(minval)
+            print(head_val)
             map=(map-minval)/(maxval-minval)*27+0
             map[np.where(np.isfinite(map) == False)]=0
             map[np.where(map < 0)]=0

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -547,6 +547,38 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHA
         sycall('gzip -f '+filename)
     return image
 
+def get_map_to_stl(map, nameid='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False,logP=False):
+    """
+    Convert a 2D map to an STL file.
+    
+    Parameters:
+    - file_out: Output STL file name.
+    - path_out: Path to save the output STL file.
+    """
+    
+    indx = np.where(map == 0)
+    indxt= np.where(map != 0)
+    map[indx] = np.nan
+    if logP:
+        map=np.log10(map)      
+    if smoth:
+        map[np.where(np.isfinite(map) == False)]=-2
+        map=filtNd(map, sigma=sig)
+    maxval=np.nanmax(map[indxt])
+    minval=np.nanmin(map[indxt])
+    map=(map-minval)/(maxval-minval)*pval+mval
+    map[np.where(np.isfinite(map) == False)]=0
+    map[indx]=0
+    map[np.where(map < 0)]=0
+    if border:
+        nx,ny=map.shape
+        map[0:1,0:ny]=0
+        map[nx-1:nx,0:ny]=0
+        map[0:nx,0:1]=0
+        map[0:nx,ny-1:ny]=0
+    # Convert the map to STL format
+    map_to_stl(map, nameid, path_out)
+
 def get_maps_to_stl(file_in, nameid='', path_in='', path_out='',sig=2,smoth=False, pval=27, mval=0, border=False):
     """
     Convert a 2D map from a FITS file to an STL file.

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -466,7 +466,7 @@ def extract_single_reg(map,hdr,ra='',dec='',rad=1.5,pix=0.35,avgra=False):
     return value
 
 
-def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5):
+def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5,save=False,path='',name='BPT_map'):
     nt1=np.where((wha >=6) & ((oiiihb-0.61/(niiha-0.47)-1.19) > 0) & (np.isfinite(oiiihb)) & (np.isnan(oiiihb) == False) & (np.isfinite(niiha)) & (np.isnan(niiha) == False))#AGN
     nt2=np.where((wha >=6) & ((oiiihb-0.61/(niiha-0.47)-1.19) <= 0) & ((oiiihb-0.61/(niiha-0.05)-1.3) > 0) & (np.isfinite(oiiihb)) & (np.isnan(niiha) == False) & (np.isfinite(niiha)) & (np.isnan(niiha) == False))#COMP
     nt3=np.where((wha >=6) & ((oiiihb-0.61/(niiha-0.05)-1.3) <= 0) & (np.isfinite(oiiihb)) & (np.isnan(niiha) == False) & (np.isfinite(niiha)) & (np.isnan(niiha) == False))#SF
@@ -480,9 +480,16 @@ def bpt(wha,niiha,oiiihb,ret=4,agn=3,sf=1,inte=2.5,comp=5):
     image[nt3]=sf
     image[nt4]=inte
     image[nt5]=ret
+    if save:
+        filename=path+name+'.fits'
+        h1=fits.PrimaryHDU(image)
+        hlist=fits.HDUList([h1])
+        hlist.update_extend()
+        hlist.writeto(filename, overwrite=True)
+        sycall('gzip -f '+filename)
     return image
 
-def whan(wha,niiha,agn=4,sf=1.7,wagn=3,ret=1):
+def whan(wha,niiha,agn=4,sf=1.7,wagn=3,ret=1,save=False,path='',name='WHAN_map'):
     nt1=np.where((wha >  6) & (niiha >= -0.4))#sAGN
     nt2=np.where((wha >= 3) & (niiha < -0.4))#SFR
     nt3=np.where((wha >= 3) & (wha <= 6) & (niiha >= -0.4))#wAGN
@@ -493,10 +500,17 @@ def whan(wha,niiha,agn=4,sf=1.7,wagn=3,ret=1):
     image[nt2]=sf
     image[nt3]=wagn
     image[nt4]=ret
+    if save:
+        filename=path+name+'.fits'
+        h1=fits.PrimaryHDU(image)
+        hlist=fits.HDUList([h1])
+        hlist.update_extend()
+        hlist.writeto(filename, overwrite=True)
+        sycall('gzip -f '+filename)
     return image    
 
 
-def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1):
+def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1,save=False,path='',name='WHAD_map'):
     nt1=np.where((logew>=np.log10(10)) & (logsig>=np.log10(57))) #AGN
     nt2=np.where((logew>=np.log10(6)) & (logsig<np.log10(57))) #SF
     nt3=np.where((logew>=np.log10(3)) & (logew<np.log10(10)) & (logsig>=np.log10(57))) #WAGN
@@ -509,6 +523,13 @@ def whad(logew,logsig,agn=5,sf=3,wagn=4,ret=2,unk=1):
     image[nt3]=wagn
     image[nt4]=ret
     image[nt5]=unk
+    if save:
+        filename=path+name+'.fits'
+        h1=fits.PrimaryHDU(image)
+        hlist=fits.HDUList([h1])
+        hlist.update_extend()
+        hlist.writeto(filename, overwrite=True)
+        sycall('gzip -f '+filename)
     return image
 
 

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -556,7 +556,7 @@ def get_maps_to_stl(file_in, nameid='', path_in='', path_out=''):
     """
     # Read the FITS file
     mapdata, hdr = fits.getdata(path_in + file_in, header=True)
-    keys = hdr.keys()
+    keys = list(hdr.keys())
     print(keys)
     for key in keys:
         if 'VAL_' in key:

--- a/MapLines/tools/tools.py
+++ b/MapLines/tools/tools.py
@@ -17,6 +17,8 @@ from astropy.wcs import WCS
 import numpy as np
 import matplotlib.tri as mtri
 from stl import mesh
+import warnings
+warnings.filterwarnings("ignore")
 
 def wfits_ext(name,hlist):
     sycall("rm "+name+'.gz')

--- a/bin/run_mapline
+++ b/bin/run_mapline
@@ -226,7 +226,7 @@ def runoned(config_file,name,path,path_out,zt,ncpus,error,bcont,name_out,kskew,o
     name_out2=name_out+waveR+skl+soutf
     config_lines=line_config_path+line_config
     line_fit_single(file1,file_out,file_out2,name_out2,input_format=input_format,z=zt,lA1=lA1,lA2=lA2,ncpu=ncpus,
-         lorentz=lorentz,skew=skew,flux_f=flux_f,erft=0.75,cont=cont,error_c=error_c,config_lines=config_lines,outflow=outf)
+         lorentz=lorentz,skew=skew,flux_f=flux_f,erft=0.75,cont=cont,error_c=error_c,config_lines=config_lines,outflow=outf,dir_out=dir_out)
 
 
 

--- a/bin/run_mapline
+++ b/bin/run_mapline
@@ -122,7 +122,6 @@ def run(config_file,name,mask,path,path_out,zt,ncpus,test,error,bcont,it,jt,spro
     file_out2=dir_out+'NAME_paramV2'.replace('NAME',name_out)+waveR+skl+soutf
     name_out2=name_out+waveR+skl+soutf
     config_lines=line_config_path+line_config
-    print(file1)
     line_fit(file1,file2,file3,file_out,file_out2,name_out2,z=zt,lA1=lA1,lA2=lA2,plot_f=plot_f,
          pgr_bar=pgr_bar,ncpu=ncpus,skew=skew,flux_f=fluxf,erft=0.75,cont=cont,test=test,
          error_c=error_c,i_t=it,j_t=jt,lorentz=lorentz,config_lines=config_lines,outflow=outf,dir_out=dir_out)
@@ -146,8 +145,10 @@ cli.add_command(run)
 @click.option('-i', '--input_format', type=str, default='CSV', help='input of the spectra file')
 @click.option('-q', '--line_config', type=str, default='line_prop.yml', help='line model configuration file')
 @click.option('-w', '--line_config_path', type=str, default='', help='path to the line model configuration file')
+@click.option('-m', '--smoth', is_flag=True, default=False, help='flag to activate a smothing of the spectra')
+@click.option('-h', '--ker', type=float, default=2, help='value in pixels of the smothin kernel')
 
-def runoned(config_file,name,path,path_out,zt,ncpus,error,bcont,name_out,kskew,outflow,fluxf,lorentz,input_format,line_config,line_config_path):
+def runoned(config_file,name,path,path_out,zt,ncpus,error,bcont,name_out,kskew,outflow,fluxf,lorentz,input_format,line_config,line_config_path,smoth,ker):
  
     wave_ini=6350.0
     wave_fin=6850.0
@@ -179,6 +180,8 @@ def runoned(config_file,name,path,path_out,zt,ncpus,error,bcont,name_out,kskew,o
             input_format=data['files'][0]['input_format']
             line_config=data['files'][0]['line_config']
             line_config_path=data['files'][0]['line_config_path']
+            smoth=data['files'][0]['smoth']
+            ker=data['files'][0]['ker']
         else:
             print('Error: The config file is not for 1D spectra')
             return
@@ -226,7 +229,7 @@ def runoned(config_file,name,path,path_out,zt,ncpus,error,bcont,name_out,kskew,o
     file_out2=dir_out+'NAME_paramV2'.replace('NAME',name_out)+waveR+skl+soutf
     name_out2=name_out+waveR+skl+soutf
     config_lines=line_config_path+line_config
-    line_fit_single(file1,file_out,file_out2,name_out2,input_format=input_format,z=zt,lA1=lA1,lA2=lA2,ncpu=ncpus,
+    line_fit_single(file1,file_out,file_out2,name_out2,input_format=input_format,z=zt,lA1=lA1,lA2=lA2,ncpu=ncpus,smoth=smoth,ker=ker,
          lorentz=lorentz,skew=skew,flux_f=flux_f,erft=0.75,cont=cont,error_c=error_c,config_lines=config_lines,outflow=outf,dir_out=dir_out)
 
 

--- a/bin/run_mapline
+++ b/bin/run_mapline
@@ -122,6 +122,7 @@ def run(config_file,name,mask,path,path_out,zt,ncpus,test,error,bcont,it,jt,spro
     file_out2=dir_out+'NAME_paramV2'.replace('NAME',name_out)+waveR+skl+soutf
     name_out2=name_out+waveR+skl+soutf
     config_lines=line_config_path+line_config
+    print(file1)
     line_fit(file1,file2,file3,file_out,file_out2,name_out2,z=zt,lA1=lA1,lA2=lA2,plot_f=plot_f,
          pgr_bar=pgr_bar,ncpu=ncpus,skew=skew,flux_f=fluxf,erft=0.75,cont=cont,test=test,
          error_c=error_c,i_t=it,j_t=jt,lorentz=lorentz,config_lines=config_lines,outflow=outf,dir_out=dir_out)

--- a/bin/run_mapline
+++ b/bin/run_mapline
@@ -124,7 +124,7 @@ def run(config_file,name,mask,path,path_out,zt,ncpus,test,error,bcont,it,jt,spro
     config_lines=line_config_path+line_config
     line_fit(file1,file2,file3,file_out,file_out2,name_out2,z=zt,lA1=lA1,lA2=lA2,plot_f=plot_f,
          pgr_bar=pgr_bar,ncpu=ncpus,skew=skew,flux_f=fluxf,erft=0.75,cont=cont,test=test,
-         error_c=error_c,i_t=it,j_t=jt,lorentz=lorentz,config_lines=config_lines,outflow=outf)
+         error_c=error_c,i_t=it,j_t=jt,lorentz=lorentz,config_lines=config_lines,outflow=outf,dir_out=dir_out)
     
 cli.add_command(run)
 

--- a/configfiles/config.yml
+++ b/configfiles/config.yml
@@ -53,6 +53,8 @@ files:
     n_line: False #flag to activate only one line component
     line_config: line_prop.yml #configuration file of the emision lines
     line_config_path: '' #path to the configuration file of the emision lines
+    smoth: False #flag to activate a smothing of the spectra
+    ker: 2 # value in pixels of the smothin kernel
     #rvel: 500.0 #narrow velocity shift range
 
     # Object Info

--- a/examples/single_spectra/config.yml
+++ b/examples/single_spectra/config.yml
@@ -24,6 +24,8 @@ files:
     error: False #flag to run autocalculate the error vector
     line_config: line_prop_Ha.yml #configuration file of the emision lines
     line_config_path: '' #path to the configuration file of the emision lines
+    smoth: False #flag to activate a smothing of the spectra
+    ker: 2 # value in pixels of the smothin kernel
     #rvel: 500.0 #narrow velocity shift range
 
     # Object Info

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requirements = [
     'emcee',
     'tqdm',
     'corner',
-    'stl',
+    'numpy-stl',
 ]
 
 DATA_DIRNAME = 'data'#'examples/example_data'

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ requirements = [
     'emcee',
     'tqdm',
     'corner',
+    'stl',
 ]
 
 DATA_DIRNAME = 'data'#'examples/example_data'


### PR DESCRIPTION
This pull request introduces several updates to the `MapLines/tools` module, focusing on enhancing error handling, adding flexibility in file I/O operations, and improving plotting capabilities. The most significant changes include updates to the `line_fit_single` and `line_fit` functions to handle missing or alternative data fields more robustly, new parameters for output customization, and the addition of a new function for plotting BPT maps. Below is a categorized summary of the most important changes:

### Enhancements to `line_fit_single` and `line_fit` Functions
* Added error handling for missing FITS data fields (`FLUX`, `LAMBDA`, `ERROR`, etc.) with fallback logic to alternative field names (e.g., `flux`, `lambda`, `fluxE`). (`[[1]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeL16-R40)`, `[[2]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeL486-R512)`)
* Introduced new parameters (`dir_out`, `smoth`, `ker`, `labplot`, etc.) to allow for more flexible output directory management, optional smoothing of data, and conditional plotting of legends. (`[[1]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeL16-R40)`, `[[2]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeL112-L116)`, `[[3]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeR816-R819)`)
* Updated file output paths for generated plots (`spectraFit_NAME.pdf`, `corners_NAME.pdf`, etc.) to include the `dir_out` parameter for better organization. (`[[1]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeL385-R398)`, `[[2]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeL397-R410)`, `[[3]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeL412-R425)`)

### New Functionality for Plotting
* Added a new `plot_bpt_map` function in `plot_tools.py` to generate BPT diagnostic maps, with support for custom colormaps, WCS projections, and saving outputs as PDF files. (`[MapLines/tools/plot_tools.pyR16-R74](diffhunk://#diff-4b33450acac39aeee1c674567d67da3dd11810a8fae87c9724f1afd2db34dedcR16-R74)`)
* Updated the `get_plot_map` function to support additional parameters like `ticks`, `labels`, and `norm` for more customizable color bar options. (`[[1]](diffhunk://#diff-4b33450acac39aeee1c674567d67da3dd11810a8fae87c9724f1afd2db34dedcL67-R127)`, `[[2]](diffhunk://#diff-4b33450acac39aeee1c674567d67da3dd11810a8fae87c9724f1afd2db34dedcR164-R186)`)

### Improvements in Data Handling
* Enhanced the `bpt` and `whan` functions in `tools.py` to optionally save the generated maps as FITS files, including header information if provided. (`[[1]](diffhunk://#diff-4baa7519bfc07c5ae21299a57e57dbf5b8dca310a98f562463044073c6430ff1L470-R480)`, `[[2]](diffhunk://#diff-4baa7519bfc07c5ae21299a57e57dbf5b8dca310a98f562463044073c6430ff1R489-R501)`)
* Improved the robustness of header updates in FITS files by adding error handling for invalid or missing header keys. (`[[1]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeR878-R920)`, `[[2]](diffhunk://#diff-80a235a19999d4719204daf7df0dd1381610ee312ae71f17f449261969faeeaeR932-R937)`)

### Miscellaneous Updates
* Added new imports, including `ListedColormap` from `matplotlib.colors` and `mesh` from `stl`, to support new functionalities. (`[[1]](diffhunk://#diff-4b33450acac39aeee1c674567d67da3dd11810a8fae87c9724f1afd2db34dedcR7)`, `[[2]](diffhunk://#diff-4baa7519bfc07c5ae21299a57e57dbf5b8dca310a98f562463044073c6430ff1R17-R21)`)
* Minor cleanup and adjustments to existing functions, such as ensuring valid ranges for BPT classifications and removing unused variables. (`[[1]](diffhunk://#diff-4baa7519bfc07c5ae21299a57e57dbf5b8dca310a98f562463044073c6430ff1L114)`, `[[2]](diffhunk://#diff-4baa7519bfc07c5ae21299a57e57dbf5b8dca310a98f562463044073c6430ff1L470-R480)`)